### PR TITLE
Add custom rector rules to fix types in parameters automatically mapped to objects

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,9 +2,24 @@
 
 declare(strict_types=1);
 
+use AmazonPHP\SellingPartner\Api\VendorOrdersApi\VendorDirectFulfillmentOrdersSDK;
+use AmazonPHP\SellingPartner\Model\CatalogItem\Item;
+use AmazonPHP\SellingPartner\Model\ListingsItems\ListingsItemPutRequest;
+use AmazonPHP\SellingPartner\Model\Messaging\GetSchemaResponse;
+use AmazonPHP\SellingPartner\Model\Uploads\UploadDestination;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\UnionType;
 use Rector\Core\Configuration\Option;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
@@ -31,4 +46,69 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SetList::PHP_73);
     $containerConfigurator->import(SetList::PHP_74);
     $containerConfigurator->import(SetList::TYPE_DECLARATION);
+
+    /**
+     * Explanation here: https://github.com/amazon-php/sp-api-sdk/issues/101#issuecomment-1002159988
+     */
+    $services->set(AddParamTypeDeclarationRector::class)
+        ->call('configure', [[
+            AddParamTypeDeclarationRector::PARAMETER_TYPEHINTS => ValueObjectInliner::inline([
+                new AddParamTypeDeclaration(
+                    Item::class,
+                    'setAttributes',
+                    0,
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())])
+                ),
+                new AddParamTypeDeclaration(
+                    ListingsItemPutRequest::class,
+                    'setAttributes',
+                    0,
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())])
+                ),
+                new AddParamTypeDeclaration(
+                    GetSchemaResponse::class,
+                    'setPayload',
+                    0,
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())])
+                ),
+                new AddParamTypeDeclaration(
+                    UploadDestination::class,
+                    'setHeaders',
+                    0,
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())])
+                ),
+                new AddParamTypeDeclaration(
+                    VendorDirectFulfillmentOrdersSDK::class,
+                    'getOrders',
+                    9,
+                    new BooleanType()
+                ),
+            ])
+        ]]);
+
+    $services->set(AddReturnTypeDeclarationRector::class)
+        ->call('configure', [[
+            AddReturnTypeDeclarationRector::METHOD_RETURN_TYPES => ValueObjectInliner::inline([
+                new AddReturnTypeDeclaration(
+                    Item::class,
+                    'getAttributes',
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())]),
+                ),
+                new AddReturnTypeDeclaration(
+                    ListingsItemPutRequest::class,
+                    'getAttributes',
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())]),
+                ),
+                new AddReturnTypeDeclaration(
+                    GetSchemaResponse::class,
+                    'getPayload',
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())]),
+                ),
+                new AddReturnTypeDeclaration(
+                    GetSchemaResponse::class,
+                    'getHeaders',
+                    new UnionType([new NullType(), new ArrayType(new MixedType(), new MixedType())]),
+                ),
+            ])
+        ]]);
 };

--- a/src/AmazonPHP/SellingPartner/Model/CatalogItem/Item.php
+++ b/src/AmazonPHP/SellingPartner/Model/CatalogItem/Item.php
@@ -284,8 +284,10 @@ class Item implements \ArrayAccess, \JsonSerializable, ModelInterface
 
     /**
      * Gets attributes.
+     *
+     * @return null|object
      */
-    public function getAttributes() : ?object
+    public function getAttributes() : ?array
     {
         return $this->container['attributes'];
     }
@@ -295,7 +297,7 @@ class Item implements \ArrayAccess, \JsonSerializable, ModelInterface
      *
      * @param null|object $attributes A JSON object that contains structured item attribute data keyed by attribute name. Catalog item attributes are available only to brand owners and conform to the related product type definitions available in the Selling Partner API for Product Type Definitions.
      */
-    public function setAttributes(?object $attributes) : self
+    public function setAttributes(?array $attributes) : self
     {
         $this->container['attributes'] = $attributes;
 

--- a/src/AmazonPHP/SellingPartner/Model/ListingsItems/ListingsItemPutRequest.php
+++ b/src/AmazonPHP/SellingPartner/Model/ListingsItems/ListingsItemPutRequest.php
@@ -313,7 +313,7 @@ class ListingsItemPutRequest implements \ArrayAccess, \JsonSerializable, ModelIn
     /**
      * Gets attributes.
      */
-    public function getAttributes() : object
+    public function getAttributes() : ?array
     {
         return $this->container['attributes'];
     }
@@ -323,7 +323,7 @@ class ListingsItemPutRequest implements \ArrayAccess, \JsonSerializable, ModelIn
      *
      * @param object $attributes JSON object containing structured listings item attribute data keyed by attribute name
      */
-    public function setAttributes(object $attributes) : self
+    public function setAttributes(?array $attributes) : self
     {
         $this->container['attributes'] = $attributes;
 

--- a/src/AmazonPHP/SellingPartner/Model/Messaging/GetSchemaResponse.php
+++ b/src/AmazonPHP/SellingPartner/Model/Messaging/GetSchemaResponse.php
@@ -242,8 +242,10 @@ class GetSchemaResponse implements \ArrayAccess, \JsonSerializable, ModelInterfa
 
     /**
      * Gets payload.
+     *
+     * @return null|object
      */
-    public function getPayload() : ?object
+    public function getPayload() : ?array
     {
         return $this->container['payload'];
     }
@@ -253,7 +255,7 @@ class GetSchemaResponse implements \ArrayAccess, \JsonSerializable, ModelInterfa
      *
      * @param null|object $payload A JSON schema document describing the expected payload of the action. This object can be validated against <a href=http://json-schema.org/draft-04/schema>http://json-schema.org/draft-04/schema</a>.
      */
-    public function setPayload(?object $payload) : self
+    public function setPayload(?array $payload) : self
     {
         $this->container['payload'] = $payload;
 

--- a/src/AmazonPHP/SellingPartner/Model/Uploads/UploadDestination.php
+++ b/src/AmazonPHP/SellingPartner/Model/Uploads/UploadDestination.php
@@ -273,7 +273,7 @@ class UploadDestination implements \ArrayAccess, \JsonSerializable, ModelInterfa
      *
      * @param null|object $headers the headers to include in the upload request
      */
-    public function setHeaders(?object $headers) : self
+    public function setHeaders(?array $headers) : self
     {
         $this->container['headers'] = $headers;
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li><code>?object</code> to <code>?array</code> types in parameters and method returns</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->