### PR TITLE
fix copy/paste issue in FixArgumentDefaultValuesNotMatchingTypeRector

### DIFF
--- a/tools/src/AmazonPHP/Rector/ClassMethod/FixArgumentDefaultValuesNotMatchingTypeRector.php
+++ b/tools/src/AmazonPHP/Rector/ClassMethod/FixArgumentDefaultValuesNotMatchingTypeRector.php
@@ -49,7 +49,6 @@ class FixArgumentDefaultValuesNotMatchingTypeRector extends AbstractRector
                     case 'false':
                     default:
                         $param->default = $this->nodeFactory->createFalse();
-                        $param->default = $this->nodeFactory->createFalse();
 
                         break;
                 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
<li>typo in rector rule</li> 
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->fixed typo in recently created rector rule

https://github.com/amazon-php/sp-api-sdk/pull/111