### PR TITLE
Update Address.php

### DIFF
--- a/src/AmazonPHP/SellingPartner/Model/Orders/Address.php
+++ b/src/AmazonPHP/SellingPartner/Model/Orders/Address.php
@@ -315,7 +315,7 @@ class Address implements \ArrayAccess, \JsonSerializable, ModelInterface
     /**
      * Gets name.
      */
-    public function getName() : string
+    public function getName() : ?string
     {
         return $this->container['name'];
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>JsonSerialization of an \AmazonPHP\SellingPartner\Model\Orders fails due to an empty name attribute on the  response filled into \AmazonPHP\SellingPartner\Model\Orders\Address. The failure is due to the expected return type. 
Fixed by adjusting the return type for string to be optional
    </li> 
  </ul>  
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->

Addresses returned by the getOrder endpoint are documented as requiring an OrderAddress Address name parameter, but responses are not conforming to that spec.

Currently, requests to JsonSerialize on an Orders object will fail when the getName method is called due to the return type. Adjusting the return to be an optional string.