### PR TITLE
Refactor SDK Facades to use child object cache

### DIFF
--- a/src/AmazonPHP/SellingPartner/SellingPartnerSDK.php
+++ b/src/AmazonPHP/SellingPartner/SellingPartnerSDK.php
@@ -39,7 +39,10 @@ use Psr\Log\LoggerInterface;
 
 final class SellingPartnerSDK
 {
-    private array $sdkCache;
+    /**
+     * @var array<class-string>
+     */
+    private array $instances;
 
     private ClientInterface $httpClient;
 
@@ -60,7 +63,7 @@ final class SellingPartnerSDK
         Configuration $configuration,
         LoggerInterface $logger
     ) {
-        $this->sdkCache = [];
+        $this->instances = [];
 
         $this->httpClient     = $httpClient;
         $this->requestFactory = $requestFactory;
@@ -83,161 +86,161 @@ final class SellingPartnerSDK
 
     public function oAuth() : OAuth
     {
-        return $this->getSellingPartnerSDKFromCache(OAuth::class);
+        return $this->instantiateSDK(OAuth::class);
     }
 
     public function aPlus() : APlusSDK
     {
-        return $this->getSellingPartnerSDKFromCache(APlusSDK::class);
+        return $this->instantiateSDK(APlusSDK::class);
     }
 
     public function authorization() : AuthorizationSDK
     {
-        return $this->getSellingPartnerSDKFromCache(AuthorizationSDK::class);
+        return $this->instantiateSDK(AuthorizationSDK::class);
     }
 
     public function catalogItem() : CatalogItemSDK
     {
-        return $this->getSellingPartnerSDKFromCache(CatalogItemSDK::class);
+        return $this->instantiateSDK(CatalogItemSDK::class);
     }
 
     public function fbaInbound() : FBAInboundSDK
     {
-        return $this->getSellingPartnerSDKFromCache(FBAInboundSDK::class);
+        return $this->instantiateSDK(FBAInboundSDK::class);
     }
 
     public function fbaInventory() : FBAInventorySDK
     {
-        return $this->getSellingPartnerSDKFromCache(FBAInventorySDK::class);
+        return $this->instantiateSDK(FBAInventorySDK::class);
     }
 
     public function fbaSmallAndLight() : FBASmallAndLightSDK
     {
-        return $this->getSellingPartnerSDKFromCache(FBASmallAndLightSDK::class);
+        return $this->instantiateSDK(FBASmallAndLightSDK::class);
     }
 
     public function feeds() : FeedsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(FeedsSDK::class);
+        return $this->instantiateSDK(FeedsSDK::class);
     }
 
     public function finances() : FinancesSDK
     {
-        return $this->getSellingPartnerSDKFromCache(FinancesSDK::class);
+        return $this->instantiateSDK(FinancesSDK::class);
     }
 
     public function fulfillmentInbound() : FulfillmentInboundSDK
     {
-        return $this->getSellingPartnerSDKFromCache(FulfillmentInboundSDK::class);
+        return $this->instantiateSDK(FulfillmentInboundSDK::class);
     }
 
     public function fulfillmentOutbound() : FulfillmentOutboundSDK
     {
-        return $this->getSellingPartnerSDKFromCache(FulfillmentOutboundSDK::class);
+        return $this->instantiateSDK(FulfillmentOutboundSDK::class);
     }
 
     public function listingsItems() : ListingsItemsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ListingsItemsSDK::class);
+        return $this->instantiateSDK(ListingsItemsSDK::class);
     }
 
     public function merchantFulfillment() : MerchantFulfillmentSDK
     {
-        return $this->getSellingPartnerSDKFromCache(MerchantFulfillmentSDK::class);
+        return $this->instantiateSDK(MerchantFulfillmentSDK::class);
     }
 
     public function messaging() : MessagingSDK
     {
-        return $this->getSellingPartnerSDKFromCache(MessagingSDK::class);
+        return $this->instantiateSDK(MessagingSDK::class);
     }
 
     public function notifications() : NotificationsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(NotificationsSDK::class);
+        return $this->instantiateSDK(NotificationsSDK::class);
     }
 
     public function orders() : OrdersV0Api\OrdersSDK
     {
-        return $this->getSellingPartnerSDKFromCache(OrdersV0Api\OrdersSDK::class);
+        return $this->instantiateSDK(OrdersV0Api\OrdersSDK::class);
     }
 
     public function orderShipment() : ShipmentApi\OrdersSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ShipmentApi\OrdersSDK::class);
+        return $this->instantiateSDK(ShipmentApi\OrdersSDK::class);
     }
 
     public function productFees() : ProductFeesSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ProductFeesSDK::class);
+        return $this->instantiateSDK(ProductFeesSDK::class);
     }
 
     public function productPricing() : ProductPricingSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ProductPricingSDK::class);
+        return $this->instantiateSDK(ProductPricingSDK::class);
     }
 
     public function productTypesDefinitions() : ProductTypesDefinitionsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ProductTypesDefinitionsSDK::class);
+        return $this->instantiateSDK(ProductTypesDefinitionsSDK::class);
     }
 
     public function reports() : ReportsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ReportsSDK::class);
+        return $this->instantiateSDK(ReportsSDK::class);
     }
 
     public function sales() : SalesSDK
     {
-        return $this->getSellingPartnerSDKFromCache(SalesSDK::class);
+        return $this->instantiateSDK(SalesSDK::class);
     }
 
     public function sellers() : SellersSDK
     {
-        return $this->getSellingPartnerSDKFromCache(SellersSDK::class);
+        return $this->instantiateSDK(SellersSDK::class);
     }
 
     public function services() : ServicesSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ServicesSDK::class);
+        return $this->instantiateSDK(ServicesSDK::class);
     }
 
     public function shipmentInvoicing() : ShipmentInvoicingSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ShipmentInvoicingSDK::class);
+        return $this->instantiateSDK(ShipmentInvoicingSDK::class);
     }
 
     public function shipping() : ShippingSDK
     {
-        return $this->getSellingPartnerSDKFromCache(ShippingSDK::class);
+        return $this->instantiateSDK(ShippingSDK::class);
     }
 
     public function solicitations() : SolicitationsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(SolicitationsSDK::class);
+        return $this->instantiateSDK(SolicitationsSDK::class);
     }
 
     public function tokens() : TokensSDK
     {
-        return $this->getSellingPartnerSDKFromCache(TokensSDK::class);
+        return $this->instantiateSDK(TokensSDK::class);
     }
 
     public function uploads() : UploadsSDK
     {
-        return $this->getSellingPartnerSDKFromCache(UploadsSDK::class);
+        return $this->instantiateSDK(UploadsSDK::class);
     }
 
     public function vendor() : VendorSDK
     {
-        return $this->getSellingPartnerSDKFromCache(VendorSDK::class);
+        return $this->instantiateSDK(VendorSDK::class);
     }
 
-    private function getSellingPartnerSDKFromCache(string $sdkClass)
+    private function instantiateSDK(string $sdkClass)
     {
-        if (isset($this->sdkCache[$sdkClass])) {
-            return $this->sdkCache[$sdkClass];
+        if (isset($this->instances[$sdkClass])) {
+            return $this->instances[$sdkClass];
         }
 
-        $this->sdkCache[$sdkClass] = ($sdkClass === VendorSDK::class)
+        $this->instances[$sdkClass] = ($sdkClass === VendorSDK::class)
             ? VendorSDK::create(
                 $this->httpClient,
                 $this->requestFactory,
@@ -252,6 +255,6 @@ final class SellingPartnerSDK
                 $this->logger
             );
 
-        return $this->sdkCache[$sdkClass];
+        return $this->instances[$sdkClass];
     }
 }

--- a/src/AmazonPHP/SellingPartner/SellingPartnerSDK.php
+++ b/src/AmazonPHP/SellingPartner/SellingPartnerSDK.php
@@ -39,128 +39,36 @@ use Psr\Log\LoggerInterface;
 
 final class SellingPartnerSDK
 {
-    private OAuth $oAuth;
+    private array $sdkCache;
 
-    private APlusSDK $aPlus;
+    private ClientInterface $httpClient;
 
-    private AuthorizationSDK $authorization;
+    private RequestFactoryInterface $requestFactory;
 
-    private CatalogItemSDK $catalogItem;
+    private StreamFactoryInterface $streamFactory;
 
-    private FBAInboundSDK $fbaInbound;
+    private Configuration $configuration;
 
-    private FBAInventorySDK $fbaInventory;
+    private LoggerInterface $logger;
 
-    private FBASmallAndLightSDK $fbaSmallAndLight;
-
-    private FeedsSDK $feeds;
-
-    private FinancesSDK $finances;
-
-    private FulfillmentInboundSDK $fulfillmentInbound;
-
-    private FulfillmentOutboundSDK $fulfillmentOutbound;
-
-    private ListingsItemsSDK $listingsItems;
-
-    private MerchantFulfillmentSDK $merchantFulfillment;
-
-    private MessagingSDK $messaging;
-
-    private NotificationsSDK $notifications;
-
-    private OrdersV0Api\OrdersSDK $orders;
-
-    private ShipmentApi\OrdersSDK $ordersShipment;
-
-    private ProductFeesSDK $productFees;
-
-    private ProductPricingSDK $productPricing;
-
-    private ProductTypesDefinitionsSDK $productTypesDefinitions;
-
-    private ReportsSDK $reports;
-
-    private SalesSDK $sales;
-
-    private SellersSDK $sellers;
-
-    private ServicesSDK $services;
-
-    private ShipmentInvoicingSDK $shipmentInvoicing;
-
-    private ShippingSDK $shipping;
-
-    private SolicitationsSDK $solicitations;
-
-    private TokensSDK $tokens;
-
-    private UploadsSDK $uploads;
-
-    private VendorSDK $vendorSDK;
+    private HttpFactory $httpFactory;
 
     public function __construct(
-        OAuth $oAuth,
-        APlusSDK $aPlus,
-        AuthorizationSDK $authorization,
-        CatalogItemSDK $catalogItem,
-        FBAInboundSDK $fbaInbound,
-        FBAInventorySDK $fbaInventory,
-        FBASmallAndLightSDK $fbaSmallAndLight,
-        FeedsSDK $feeds,
-        FinancesSDK $finances,
-        FulfillmentInboundSDK $fulfillmentInbound,
-        FulfillmentOutboundSDK $fulfillmentOutbound,
-        ListingsItemsSDK $listingsItems,
-        MerchantFulfillmentSDK $merchantFulfillment,
-        MessagingSDK $messaging,
-        NotificationsSDK $notifications,
-        OrdersV0Api\OrdersSDK $orders,
-        ShipmentApi\OrdersSDK $ordersShipment,
-        ProductFeesSDK $productFees,
-        ProductPricingSDK $productPricing,
-        ProductTypesDefinitionsSDK $productTypesDefinitions,
-        ReportsSDK $reports,
-        SalesSDK $sales,
-        SellersSDK $sellers,
-        ServicesSDK $services,
-        ShipmentInvoicingSDK $shipmentInvoicing,
-        ShippingSDK $shipping,
-        SolicitationsSDK $solicitations,
-        TokensSDK $tokens,
-        UploadsSDK $uploads,
-        VendorSDK $vendorSDK
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        Configuration $configuration,
+        LoggerInterface $logger
     ) {
-        $this->oAuth = $oAuth;
-        $this->aPlus = $aPlus;
-        $this->authorization = $authorization;
-        $this->catalogItem = $catalogItem;
-        $this->fbaInbound = $fbaInbound;
-        $this->fbaInventory = $fbaInventory;
-        $this->fbaSmallAndLight = $fbaSmallAndLight;
-        $this->feeds = $feeds;
-        $this->finances = $finances;
-        $this->fulfillmentInbound = $fulfillmentInbound;
-        $this->fulfillmentOutbound = $fulfillmentOutbound;
-        $this->listingsItems = $listingsItems;
-        $this->merchantFulfillment = $merchantFulfillment;
-        $this->messaging = $messaging;
-        $this->notifications = $notifications;
-        $this->orders = $orders;
-        $this->ordersShipment = $ordersShipment;
-        $this->productFees = $productFees;
-        $this->productPricing = $productPricing;
-        $this->productTypesDefinitions = $productTypesDefinitions;
-        $this->reports = $reports;
-        $this->sales = $sales;
-        $this->sellers = $sellers;
-        $this->services = $services;
-        $this->shipmentInvoicing = $shipmentInvoicing;
-        $this->shipping = $shipping;
-        $this->solicitations = $solicitations;
-        $this->tokens = $tokens;
-        $this->uploads = $uploads;
-        $this->vendorSDK = $vendorSDK;
+        $this->sdkCache = [];
+
+        $this->httpClient     = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory  = $streamFactory;
+        $this->configuration  = $configuration;
+        $this->logger         = $logger;
+
+        $this->httpFactory = new HttpFactory($requestFactory, $streamFactory);
     }
 
     public static function create(
@@ -170,189 +78,180 @@ final class SellingPartnerSDK
         Configuration $configuration,
         LoggerInterface $logger
     ) : self {
-        $httpFactory = new HttpFactory($requestFactory, $streamFactory);
-
-        return new self(
-            new OAuth($httpClient, $httpFactory, $configuration, $logger),
-            new APlusSDK($httpClient, $httpFactory, $configuration, $logger),
-            new AuthorizationSDK($httpClient, $httpFactory, $configuration, $logger),
-            new CatalogItemSDK($httpClient, $httpFactory, $configuration, $logger),
-            new FBAInboundSDK($httpClient, $httpFactory, $configuration, $logger),
-            new FBAInventorySDK($httpClient, $httpFactory, $configuration, $logger),
-            new FBASmallAndLightSDK($httpClient, $httpFactory, $configuration, $logger),
-            new FeedsSDK($httpClient, $httpFactory, $configuration, $logger),
-            new FinancesSDK($httpClient, $httpFactory, $configuration, $logger),
-            new FulfillmentInboundSDK($httpClient, $httpFactory, $configuration, $logger),
-            new FulfillmentOutboundSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ListingsItemsSDK($httpClient, $httpFactory, $configuration, $logger),
-            new MerchantFulfillmentSDK($httpClient, $httpFactory, $configuration, $logger),
-            new MessagingSDK($httpClient, $httpFactory, $configuration, $logger),
-            new NotificationsSDK($httpClient, $httpFactory, $configuration, $logger),
-            new OrdersV0Api\OrdersSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ShipmentApi\OrdersSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ProductFeesSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ProductPricingSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ProductTypesDefinitionsSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ReportsSDK($httpClient, $httpFactory, $configuration, $logger),
-            new SalesSDK($httpClient, $httpFactory, $configuration, $logger),
-            new SellersSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ServicesSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ShipmentInvoicingSDK($httpClient, $httpFactory, $configuration, $logger),
-            new ShippingSDK($httpClient, $httpFactory, $configuration, $logger),
-            new SolicitationsSDK($httpClient, $httpFactory, $configuration, $logger),
-            new TokensSDK($httpClient, $httpFactory, $configuration, $logger),
-            new UploadsSDK($httpClient, $httpFactory, $configuration, $logger),
-            VendorSDK::create($httpClient, $requestFactory, $streamFactory, $configuration, $logger)
-        );
+        return new self($httpClient, $requestFactory, $streamFactory, $configuration, $logger);
     }
 
     public function oAuth() : OAuth
     {
-        return $this->oAuth;
+        return $this->getSellingPartnerSDKFromCache(OAuth::class);
     }
 
     public function aPlus() : APlusSDK
     {
-        return $this->aPlus;
+        return $this->getSellingPartnerSDKFromCache(APlusSDK::class);
     }
 
     public function authorization() : AuthorizationSDK
     {
-        return $this->authorization;
+        return $this->getSellingPartnerSDKFromCache(AuthorizationSDK::class);
     }
 
     public function catalogItem() : CatalogItemSDK
     {
-        return $this->catalogItem;
+        return $this->getSellingPartnerSDKFromCache(CatalogItemSDK::class);
     }
 
     public function fbaInbound() : FBAInboundSDK
     {
-        return $this->fbaInbound;
+        return $this->getSellingPartnerSDKFromCache(FBAInboundSDK::class);
     }
 
     public function fbaInventory() : FBAInventorySDK
     {
-        return $this->fbaInventory;
+        return $this->getSellingPartnerSDKFromCache(FBAInventorySDK::class);
     }
 
     public function fbaSmallAndLight() : FBASmallAndLightSDK
     {
-        return $this->fbaSmallAndLight;
+        return $this->getSellingPartnerSDKFromCache(FBASmallAndLightSDK::class);
     }
 
     public function feeds() : FeedsSDK
     {
-        return $this->feeds;
+        return $this->getSellingPartnerSDKFromCache(FeedsSDK::class);
     }
 
     public function finances() : FinancesSDK
     {
-        return $this->finances;
+        return $this->getSellingPartnerSDKFromCache(FinancesSDK::class);
     }
 
     public function fulfillmentInbound() : FulfillmentInboundSDK
     {
-        return $this->fulfillmentInbound;
+        return $this->getSellingPartnerSDKFromCache(FulfillmentInboundSDK::class);
     }
 
     public function fulfillmentOutbound() : FulfillmentOutboundSDK
     {
-        return $this->fulfillmentOutbound;
+        return $this->getSellingPartnerSDKFromCache(FulfillmentOutboundSDK::class);
     }
 
     public function listingsItems() : ListingsItemsSDK
     {
-        return $this->listingsItems;
+        return $this->getSellingPartnerSDKFromCache(ListingsItemsSDK::class);
     }
 
     public function merchantFulfillment() : MerchantFulfillmentSDK
     {
-        return $this->merchantFulfillment;
+        return $this->getSellingPartnerSDKFromCache(MerchantFulfillmentSDK::class);
     }
 
     public function messaging() : MessagingSDK
     {
-        return $this->messaging;
+        return $this->getSellingPartnerSDKFromCache(MessagingSDK::class);
     }
 
     public function notifications() : NotificationsSDK
     {
-        return $this->notifications;
+        return $this->getSellingPartnerSDKFromCache(NotificationsSDK::class);
     }
 
     public function orders() : OrdersV0Api\OrdersSDK
     {
-        return $this->orders;
+        return $this->getSellingPartnerSDKFromCache(OrdersV0Api\OrdersSDK::class);
     }
 
     public function orderShipment() : ShipmentApi\OrdersSDK
     {
-        return $this->ordersShipment;
+        return $this->getSellingPartnerSDKFromCache(ShipmentApi\OrdersSDK::class);
     }
 
     public function productFees() : ProductFeesSDK
     {
-        return $this->productFees;
+        return $this->getSellingPartnerSDKFromCache(ProductFeesSDK::class);
     }
 
     public function productPricing() : ProductPricingSDK
     {
-        return $this->productPricing;
+        return $this->getSellingPartnerSDKFromCache(ProductPricingSDK::class);
     }
 
     public function productTypesDefinitions() : ProductTypesDefinitionsSDK
     {
-        return $this->productTypesDefinitions;
+        return $this->getSellingPartnerSDKFromCache(ProductTypesDefinitionsSDK::class);
     }
 
     public function reports() : ReportsSDK
     {
-        return $this->reports;
+        return $this->getSellingPartnerSDKFromCache(ReportsSDK::class);
     }
 
     public function sales() : SalesSDK
     {
-        return $this->sales;
+        return $this->getSellingPartnerSDKFromCache(SalesSDK::class);
     }
 
     public function sellers() : SellersSDK
     {
-        return $this->sellers;
+        return $this->getSellingPartnerSDKFromCache(SellersSDK::class);
     }
 
     public function services() : ServicesSDK
     {
-        return $this->services;
+        return $this->getSellingPartnerSDKFromCache(ServicesSDK::class);
     }
 
     public function shipmentInvoicing() : ShipmentInvoicingSDK
     {
-        return $this->shipmentInvoicing;
+        return $this->getSellingPartnerSDKFromCache(ShipmentInvoicingSDK::class);
     }
 
     public function shipping() : ShippingSDK
     {
-        return $this->shipping;
+        return $this->getSellingPartnerSDKFromCache(ShippingSDK::class);
     }
 
     public function solicitations() : SolicitationsSDK
     {
-        return $this->solicitations;
+        return $this->getSellingPartnerSDKFromCache(SolicitationsSDK::class);
     }
 
     public function tokens() : TokensSDK
     {
-        return $this->tokens;
+        return $this->getSellingPartnerSDKFromCache(TokensSDK::class);
     }
 
     public function uploads() : UploadsSDK
     {
-        return $this->uploads;
+        return $this->getSellingPartnerSDKFromCache(UploadsSDK::class);
     }
 
     public function vendor() : VendorSDK
     {
-        return $this->vendorSDK;
+        return $this->getSellingPartnerSDKFromCache(VendorSDK::class);
+    }
+
+    private function getSellingPartnerSDKFromCache(string $sdkClass)
+    {
+        if (isset($this->sdkCache[$sdkClass])) {
+            return $this->sdkCache[$sdkClass];
+        }
+
+        $this->sdkCache[$sdkClass] = ($sdkClass === VendorSDK::class)
+            ? VendorSDK::create(
+                $this->httpClient,
+                $this->requestFactory,
+                $this->streamFactory,
+                $this->configuration,
+                $this->logger
+            )
+            : new $sdkClass(
+                $this->httpClient,
+                $this->httpFactory,
+                $this->configuration,
+                $this->logger
+            );
+
+        return $this->sdkCache[$sdkClass];
     }
 }

--- a/src/AmazonPHP/SellingPartner/VendorSDK.php
+++ b/src/AmazonPHP/SellingPartner/VendorSDK.php
@@ -18,7 +18,10 @@ use Psr\Log\LoggerInterface;
 
 final class VendorSDK
 {
-    private array $sdkCache;
+    /**
+     * @var array<class-string>
+     */
+    private array $instances;
 
     private ClientInterface $httpClient;
 
@@ -35,7 +38,7 @@ final class VendorSDK
         Configuration $configuration,
         LoggerInterface $logger
     ) {
-        $this->sdkCache = [];
+        $this->instances = [];
 
         $this->httpClient     = $httpClient;
         $this->configuration  = $configuration;
@@ -56,67 +59,67 @@ final class VendorSDK
 
     public function ordersSDK() : VendorDirectFulfillmentOrdersSDK
     {
-        return $this->getVendorSDKFromCache(VendorDirectFulfillmentOrdersSDK::class);
+        return $this->instantiateSDK(VendorDirectFulfillmentOrdersSDK::class);
     }
 
     public function invoicesSDK() : VendorInvoicesSDK
     {
-        return $this->getVendorSDKFromCache(VendorInvoicesSDK::class);
+        return $this->instantiateSDK(VendorInvoicesSDK::class);
     }
 
     public function shipmentsSDK() : VendorShipmentsSDK
     {
-        return $this->getVendorSDKFromCache(VendorShipmentsSDK::class);
+        return $this->instantiateSDK(VendorShipmentsSDK::class);
     }
 
     public function transactionStatusSDK() : VendorTransactionStatusSDK
     {
-        return $this->getVendorSDKFromCache(VendorTransactionStatusSDK::class);
+        return $this->instantiateSDK(VendorTransactionStatusSDK::class);
     }
 
     public function directFulfillmentPaymentsSDK() : VendorDirectFulfillmentPaymentsSDK
     {
-        return $this->getVendorSDKFromCache(VendorDirectFulfillmentPaymentsSDK::class);
+        return $this->instantiateSDK(VendorDirectFulfillmentPaymentsSDK::class);
     }
 
     public function vendorDirectFulfillmentOrdersSDK() : VendorDirectFulfillmentOrdersSDK
     {
-        return $this->getVendorSDKFromCache(VendorDirectFulfillmentOrdersSDK::class);
+        return $this->instantiateSDK(VendorDirectFulfillmentOrdersSDK::class);
     }
 
     public function directFulfillmentOrdersSDK() : VendorDirectFulfillmentOrdersSDK
     {
-        return $this->getVendorSDKFromCache(VendorDirectFulfillmentOrdersSDK::class);
+        return $this->instantiateSDK(VendorDirectFulfillmentOrdersSDK::class);
     }
 
     public function directFulfillmentShippingSDK() : VendorDirectFulfillmentShippingSDK
     {
-        return $this->getVendorSDKFromCache(VendorDirectFulfillmentShippingSDK::class);
+        return $this->instantiateSDK(VendorDirectFulfillmentShippingSDK::class);
     }
 
     public function directFulfillmentShippingLabelsSDK() : Api\VendorShippingLabelsApi\VendorDirectFulfillmentShippingSDK
     {
-        return $this->getVendorSDKFromCache(Api\VendorShippingLabelsApi\VendorDirectFulfillmentShippingSDK::class);
+        return $this->instantiateSDK(Api\VendorShippingLabelsApi\VendorDirectFulfillmentShippingSDK::class);
     }
 
     public function directFulfillmentTransactionsSDK() : VendorDirectFulfillmentTransactionsSDK
     {
-        return $this->getVendorSDKFromCache(VendorDirectFulfillmentTransactionsSDK::class);
+        return $this->instantiateSDK(VendorDirectFulfillmentTransactionsSDK::class);
     }
 
-    private function getVendorSDKFromCache(string $sdkClass)
+    private function instantiateSDK(string $sdkClass)
     {
-        if (isset($this->sdkCache[$sdkClass])) {
-            return $this->sdkCache[$sdkClass];
+        if (isset($this->instances[$sdkClass])) {
+            return $this->instances[$sdkClass];
         }
 
-        $this->sdkCache[$sdkClass] = new $sdkClass(
+        $this->instances[$sdkClass] = new $sdkClass(
             $this->httpClient,
             $this->httpFactory,
             $this->configuration,
             $this->logger
         );
 
-        return $this->sdkCache[$sdkClass];
+        return $this->instances[$sdkClass];
     }
 }

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/SellingPartnerSDKTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/SellingPartnerSDKTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Unit;
+
+use AmazonPHP\SellingPartner\Api\AplusContentApi\APlusSDK;
+use AmazonPHP\SellingPartner\Api\AuthorizationApi\AuthorizationSDK;
+use AmazonPHP\SellingPartner\Api\CatalogApi\CatalogItemSDK;
+use AmazonPHP\SellingPartner\Api\DefaultApi\FinancesSDK;
+use AmazonPHP\SellingPartner\Api\DefinitionsApi\ProductTypesDefinitionsSDK;
+use AmazonPHP\SellingPartner\Api\FbaInboundApi\FBAInboundSDK;
+use AmazonPHP\SellingPartner\Api\FbaInboundApi\FulfillmentInboundSDK;
+use AmazonPHP\SellingPartner\Api\FbaInventoryApi\FBAInventorySDK;
+use AmazonPHP\SellingPartner\Api\FbaOutboundApi\FulfillmentOutboundSDK;
+use AmazonPHP\SellingPartner\Api\FeedsApi\FeedsSDK;
+use AmazonPHP\SellingPartner\Api\FeesApi\ProductFeesSDK;
+use AmazonPHP\SellingPartner\Api\ListingsApi\ListingsItemsSDK;
+use AmazonPHP\SellingPartner\Api\MerchantFulfillmentApi\MerchantFulfillmentSDK;
+use AmazonPHP\SellingPartner\Api\MessagingApi\MessagingSDK;
+use AmazonPHP\SellingPartner\Api\NotificationsApi\NotificationsSDK;
+use AmazonPHP\SellingPartner\Api\OrdersV0Api;
+use AmazonPHP\SellingPartner\Api\ProductPricingApi\ProductPricingSDK;
+use AmazonPHP\SellingPartner\Api\ReportsApi\ReportsSDK;
+use AmazonPHP\SellingPartner\Api\SalesApi\SalesSDK;
+use AmazonPHP\SellingPartner\Api\SellersApi\SellersSDK;
+use AmazonPHP\SellingPartner\Api\ServiceApi\ServicesSDK;
+use AmazonPHP\SellingPartner\Api\ShipmentApi;
+use AmazonPHP\SellingPartner\Api\ShipmentInvoiceApi\ShipmentInvoicingSDK;
+use AmazonPHP\SellingPartner\Api\ShippingApi\ShippingSDK;
+use AmazonPHP\SellingPartner\Api\SmallAndLightApi\FBASmallAndLightSDK;
+use AmazonPHP\SellingPartner\Api\SolicitationsApi\SolicitationsSDK;
+use AmazonPHP\SellingPartner\Api\TokensApi\TokensSDK;
+use AmazonPHP\SellingPartner\Api\UploadsApi\UploadsSDK;
+use AmazonPHP\SellingPartner\Configuration;
+use AmazonPHP\SellingPartner\OAuth;
+use AmazonPHP\SellingPartner\SellingPartnerSDK;
+use AmazonPHP\SellingPartner\VendorSDK;
+use Buzz\Client\Curl;
+use Monolog\Logger;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+final class SellingPartnerSDKTest extends TestCase
+{
+    private ?RequestFactoryInterface $requestFactory;
+
+    private ?StreamFactoryInterface $streamFactory;
+
+    private ?ClientInterface $httpClient;
+
+    private ?Configuration $configuration;
+
+    private ?LoggerInterface $logger;
+
+    private array $sdkMap = [
+        'oAuth'                   => OAuth::class,
+        'aPlus'                   => APlusSDK::class,
+        'authorization'           => AuthorizationSDK::class,
+        'catalogItem'             => CatalogItemSDK::class,
+        'fbaInbound'              => FBAInboundSDK::class,
+        'fbaInventory'            => FBAInventorySDK::class,
+        'fbaSmallAndLight'        => FBASmallAndLightSDK::class,
+        'feeds'                   => FeedsSDK::class,
+        'finances'                => FinancesSDK::class,
+        'fulfillmentInbound'      => FulfillmentInboundSDK::class,
+        'fulfillmentOutbound'     => FulfillmentOutboundSDK::class,
+        'listingsItems'           => ListingsItemsSDK::class,
+        'merchantFulfillment'     => MerchantFulfillmentSDK::class,
+        'messaging'               => MessagingSDK::class,
+        'notifications'           => NotificationsSDK::class,
+        'orders'                  => OrdersV0Api\OrdersSDK::class,
+        'orderShipment'           => ShipmentApi\OrdersSDK::class,
+        'productFees'             => ProductFeesSDK::class,
+        'productPricing'          => ProductPricingSDK::class,
+        'productTypesDefinitions' => ProductTypesDefinitionsSDK::class,
+        'reports'                 => ReportsSDK::class,
+        'sales'                   => SalesSDK::class,
+        'sellers'                 => SellersSDK::class,
+        'services'                => ServicesSDK::class,
+        'shipmentInvoicing'       => ShipmentInvoicingSDK::class,
+        'shipping'                => ShippingSDK::class,
+        'solicitations'           => SolicitationsSDK::class,
+        'tokens'                  => TokensSDK::class,
+        'uploads'                 => UploadsSDK::class,
+        'vendor'                  => VendorSDK::class,
+    ];
+
+    protected function setUp() : void
+    {
+        $this->requestFactory = new Psr17Factory();
+        $this->streamFactory  = new Psr17Factory();
+        $this->httpClient     = new Curl($this->requestFactory);
+        $this->configuration  = Configuration::forIAMUser('testId', 'testSecret', 'testAccessKey', 'testSecretKey');
+        $this->logger         = new Logger('testLogger');
+    }
+
+    protected function tearDown() : void
+    {
+        $this->requestFactory = null;
+        $this->streamFactory  = null;
+        $this->httpClient     = null;
+        $this->configuration  = null;
+        $this->logger         = null;
+    }
+
+    public function test_initialization_from_constructor() : void
+    {
+        $this->assertInstanceOf(
+            SellingPartnerSDK::class,
+            new SellingPartnerSDK(
+                $this->httpClient,
+                $this->requestFactory,
+                $this->streamFactory,
+                $this->configuration,
+                $this->logger
+            )
+        );
+    }
+
+    public function test_initialization_from_create_method() : void
+    {
+        $this->assertInstanceOf(
+            SellingPartnerSDK::class,
+            $this->getSellingPartnerSDKByCreate()
+        );
+    }
+
+    public function test_initialization_of_child_sdks() : void
+    {
+        $sellingPartnerSDK = $this->getSellingPartnerSDKByCreate();
+
+        foreach ($this->sdkMap as $method => $class) {
+            $this->assertInstanceOf($class, $sellingPartnerSDK->{$method}());
+        }
+    }
+
+    public function test_child_sdks_are_properly_cached() : void
+    {
+        $sellingPartnerSDK = $this->getSellingPartnerSDKByCreate();
+
+        foreach ($this->sdkMap as $method => $class) {
+            $childSDKOne = $sellingPartnerSDK->{$method}();
+            $childSDKTwo = $sellingPartnerSDK->{$method}();
+
+            $this->assertSame(
+                $childSDKOne,
+                $childSDKTwo,
+                'Failed asserting that two variables reference the same ' . $class . ' object.'
+            );
+        }
+    }
+
+    private function getSellingPartnerSDKByCreate() : SellingPartnerSDK
+    {
+        return SellingPartnerSDK::create(
+            $this->httpClient,
+            $this->requestFactory,
+            $this->streamFactory,
+            $this->configuration,
+            $this->logger
+        );
+    }
+}

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/VendorSDKTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/VendorSDKTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Unit;
+
+use AmazonPHP\SellingPartner\Api\VendorInvoiceApi\VendorDirectFulfillmentPaymentsSDK;
+use AmazonPHP\SellingPartner\Api\VendorOrdersApi\VendorDirectFulfillmentOrdersSDK;
+use AmazonPHP\SellingPartner\Api\VendorPaymentsApi\VendorInvoicesSDK;
+use AmazonPHP\SellingPartner\Api\VendorShippingApi\VendorDirectFulfillmentShippingSDK;
+use AmazonPHP\SellingPartner\Api\VendorShippingApi\VendorShipmentsSDK;
+use AmazonPHP\SellingPartner\Api\VendorShippingLabelsApi\VendorDirectFulfillmentShippingSDK as VendorDirectFulfillmentShippingLabelsSDK;
+use AmazonPHP\SellingPartner\Api\VendorTransactionApi\VendorDirectFulfillmentTransactionsSDK;
+use AmazonPHP\SellingPartner\Api\VendorTransactionApi\VendorTransactionStatusSDK;
+use AmazonPHP\SellingPartner\Configuration;
+use AmazonPHP\SellingPartner\VendorSDK;
+use Buzz\Client\Curl;
+use Monolog\Logger;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+final class VendorSDKTest extends TestCase
+{
+    private ?RequestFactoryInterface $requestFactory;
+
+    private ?StreamFactoryInterface $streamFactory;
+
+    private ?ClientInterface $httpClient;
+
+    private ?Configuration $configuration;
+
+    private ?LoggerInterface $logger;
+
+    private array $sdkMap = [
+        'ordersSDK'                          => VendorDirectFulfillmentOrdersSDK::class,
+        'invoicesSDK'                        => VendorInvoicesSDK::class,
+        'shipmentsSDK'                       => VendorShipmentsSDK::class,
+        'transactionStatusSDK'               => VendorTransactionStatusSDK::class,
+        'directFulfillmentPaymentsSDK'       => VendorDirectFulfillmentPaymentsSDK::class,
+        'vendorDirectFulfillmentOrdersSDK'   => VendorDirectFulfillmentOrdersSDK::class,
+        'directFulfillmentOrdersSDK'         => VendorDirectFulfillmentOrdersSDK::class,
+        'directFulfillmentShippingSDK'       => VendorDirectFulfillmentShippingSDK::class,
+        'directFulfillmentShippingLabelsSDK' => VendorDirectFulfillmentShippingLabelsSDK::class,
+        'directFulfillmentTransactionsSDK'   => VendorDirectFulfillmentTransactionsSDK::class,
+    ];
+
+    protected function setUp() : void
+    {
+        $this->requestFactory = new Psr17Factory();
+        $this->streamFactory  = new Psr17Factory();
+        $this->httpClient     = new Curl($this->requestFactory);
+        $this->configuration  = Configuration::forIAMUser('testId', 'testSecret', 'testAccessKey', 'testSecretKey');
+        $this->logger         = new Logger('testLogger');
+    }
+
+    protected function tearDown() : void
+    {
+        $this->requestFactory = null;
+        $this->streamFactory  = null;
+        $this->httpClient     = null;
+        $this->configuration  = null;
+        $this->logger         = null;
+    }
+
+    public function test_initialization_from_constructor() : void
+    {
+        $this->assertInstanceOf(
+            VendorSDK::class,
+            new VendorSDK(
+                $this->httpClient,
+                $this->requestFactory,
+                $this->streamFactory,
+                $this->configuration,
+                $this->logger
+            )
+        );
+    }
+
+    public function test_initialization_from_create_method() : void
+    {
+        $this->assertInstanceOf(
+            VendorSDK::class,
+            $this->getVendorSDKByCreate()
+        );
+    }
+
+    public function test_initialization_of_child_sdks() : void
+    {
+        $vendorSDK = $this->getVendorSDKByCreate();
+
+        foreach ($this->sdkMap as $method => $class) {
+            $this->assertInstanceOf($class, $vendorSDK->{$method}());
+        }
+    }
+
+    public function test_child_sdks_are_properly_cached() : void
+    {
+        $vendorSDK = $this->getVendorSDKByCreate();
+
+        foreach ($this->sdkMap as $method => $class) {
+            $childSDKOne = $vendorSDK->{$method}();
+            $childSDKTwo = $vendorSDK->{$method}();
+
+            $this->assertSame(
+                $childSDKOne,
+                $childSDKTwo,
+                'Failed asserting that two variables reference the same ' . $class . ' object.'
+            );
+        }
+    }
+
+    private function getVendorSDKByCreate() : VendorSDK
+    {
+        return VendorSDK::create(
+            $this->httpClient,
+            $this->requestFactory,
+            $this->streamFactory,
+            $this->configuration,
+            $this->logger
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>`SellingPartnerSDK` and `VendorSDK` facade classes now cache child SDK instances</li>
    <li>`SellingPartnerSDK` and `VendorSDK` facade class constructor signatures have been changed. Suggested to use static `create` method for instantiation.</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<p>The `SellingPartnerSDK` and `VendorSDK` facade classes now cache child SDK instances when requested to prevent unnecessary overhead. The previous implementation instantiated and stored all child SDK classes upon parent class instantiation. This created unnecessary overhead of rarely used instances.</p>
<p>Added tests for `SellingPartnerSDK` and `VendorSDK` facade classes.</p>