### PR TITLE
use PHP_QUERY_RFC3986 in query builder for signatureCalculation

### DIFF
--- a/src/AmazonPHP/SellingPartner/HttpSignatureHeaders.php
+++ b/src/AmazonPHP/SellingPartner/HttpSignatureHeaders.php
@@ -97,7 +97,7 @@ final class HttpSignatureHeaders
         //prepare canonical request
         $canonicalString = $request->getMethod()
             . "\n" . $request->getUri()->getPath()
-            . "\n" . \http_build_query($queryElements)
+            . "\n" . \http_build_query($queryElements, "", "&", PHP_QUERY_RFC3986)
             . "\n" . $canonicalHeadersStr
             . "\n" . $signedHeadersStr
             . "\n" . $hashedPayload;
@@ -228,7 +228,7 @@ final class HttpSignatureHeaders
         //prepare canonical request
         $canonicalString = $request->getMethod()
             . "\n" . $request->getUri()->getPath()
-            . "\n" . \http_build_query($queryElements)
+            . "\n" . \http_build_query($queryElements, "", "&", PHP_QUERY_RFC3986)
             . "\n" . $canonicalHeadersStr
             . "\n" . $signedHeadersStr
             . "\n" . $hashedPayload;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
     <li>Fixed InvalidSignature error in case query contains space.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
     <li>In function what calculate signature for request default encoding type PHP_QUERY_RFC1738 changed to PHP_QUERY_RFC3986 </li>
  </ul>  
  
</div>
<hr/>

<h2>Description</h2>

To repeat this problem pass sellerSku with space to getInventorySummaries() function.

The problem happens because http_build_query() use default encoding type PHP_QUERY_RFC1738 what changes space to `+` but Amazon use `%20` on their side. So http_build_query() should use PHP_QUERY_RFC3986 encoding type.

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->