### PR TITLE
Topic/convert headers to lowercase when calculating signature

### DIFF
--- a/src/AmazonPHP/SellingPartner/HttpSignatureHeaders.php
+++ b/src/AmazonPHP/SellingPartner/HttpSignatureHeaders.php
@@ -73,7 +73,9 @@ final class HttpSignatureHeaders
         $canonicalHeaders = [];
 
         foreach ($allHeaders as $headerName => $headerValue) {
-            if (\in_array(\strtolower($headerName), $blacklistHeaders, true)) {
+            $headerName = \strtolower($headerName);
+
+            if (\in_array($headerName, $blacklistHeaders, true)) {
                 continue;
             }
 
@@ -204,17 +206,19 @@ final class HttpSignatureHeaders
         $canonicalHeaders = [];
 
         foreach ($allHeaders as $headerName => $headerValue) {
-            if (\in_array(\strtolower($headerName), $blacklistHeaders, true)) {
+            $headerName = \strtolower($headerName);
+
+            if (\in_array($headerName, $blacklistHeaders, true)) {
                 continue;
             }
 
-            $canonicalHeaders[\strtolower($headerName)] = $headerValue;
+            $canonicalHeaders[$headerName] = $headerValue;
 
             if (\count($headerValue) > 0) {
                 \sort($headerValue);
             }
 
-            $canonicalHeadersStr .= \strtolower($headerName) . ':' . \implode(',', $headerValue) . "\n";
+            $canonicalHeadersStr .= $headerName . ':' . \implode(',', $headerValue) . "\n";
         }
 
         $signedHeadersStr = \implode(';', \array_keys($canonicalHeaders));

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/HttpSignatureHeadersTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/HttpSignatureHeadersTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Unit;
+
+use AmazonPHP\SellingPartner\AccessToken;
+use AmazonPHP\SellingPartner\Configuration;
+use AmazonPHP\SellingPartner\HttpSignatureHeaders;
+use AmazonPHP\SellingPartner\Regions;
+use Nyholm\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+
+class HttpSignatureHeadersTest extends TestCase
+{
+    private ?Configuration $configuration;
+
+    private ?AccessToken $accessToken;
+
+    protected function setUp(): void
+    {
+        $this->configuration = Configuration::forIAMUser('testId', 'testSecret', 'testAccessKey', 'testSecretKey');
+        $this->accessToken   = new AccessToken('testAccessToken', 'testRefreshToken', 'bearer', 3600, 'refresh_token');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->configuration = null;
+        $this->accessToken   = null;
+    }
+
+    public function test_converts_header_names_to_lowercase(): void
+    {
+        $request = new Request(
+            'GET',
+            'https://sellingpartnerapi-fe.amazon.com/sellers/v1/marketplaceParticipations',
+            // both guzzlehttp/psr7 and nyholm/psr7 infer the host from the URI as "Host" (capitalized).
+            // explicitly specifying uppercase in-case behaviour of the PSR7 library used in the test changes.
+            ['Host' => ['sellingpartnerapi-fe.amazon.com']]
+        );
+        $signedRequest = HttpSignatureHeaders::forConfig(
+            $this->configuration,
+            $this->accessToken,
+            Regions::FAR_EAST,
+            $request
+        );
+
+        $this->assertMatchesRegularExpression(
+            '#^AWS4-HMAC-SHA256 Credential=testAccessKey/20220531/us-west-2/execute-api/aws4_request, ' .
+            'SignedHeaders=host;x-amz-access-token;x-amz-date, ' .
+            'Signature=[0-9a-f]{64}$#',
+            $signedRequest->getHeader('Authorization')[0]
+        );
+    }
+}

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/HttpSignatureHeadersTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/HttpSignatureHeadersTest.php
@@ -29,6 +29,7 @@ class HttpSignatureHeadersTest extends TestCase
 
     public function test_converts_header_names_to_lowercase(): void
     {
+        $shortDate = gmdate('Ymd');
         $request = new Request(
             'GET',
             'https://sellingpartnerapi-fe.amazon.com/sellers/v1/marketplaceParticipations',
@@ -44,9 +45,9 @@ class HttpSignatureHeadersTest extends TestCase
         );
 
         $this->assertMatchesRegularExpression(
-            '#^AWS4-HMAC-SHA256 Credential=testAccessKey/20220531/us-west-2/execute-api/aws4_request, ' .
-            'SignedHeaders=host;x-amz-access-token;x-amz-date, ' .
-            'Signature=[0-9a-f]{64}$#',
+            "#^AWS4-HMAC-SHA256 Credential=testAccessKey/$shortDate/us-west-2/execute-api/aws4_request, " .
+            "SignedHeaders=host;x-amz-access-token;x-amz-date, " .
+            "Signature=[0-9a-f]{64}$#",
             $signedRequest->getHeader('Authorization')[0]
         );
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>HttpSignatureHeaders::forConfig will convert header names to lowercase when calculating the signature to avoid mismatched signatures when sending to Amazon and match behaviour of HttpSignatureHeaders::raw.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Updated HttpSignatureHeaders::forConfig to convert headers to lowercase when calculating signature. guzzle/nyholm psr7 libraries infer the "Host" header (capitalized) from the URI if not explicitly specified. User may also specify other headers which aren't already lowercased.

Amazon requires header names to be lowercased before generating the hash (https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html):
"To create the canonical headers list, convert all header names to lowercase ...".

Mixed header case was already somewhat handled but inconsistent across different functions.

My use case for this is we are looking to use this library for fetching tokens and signing/attaching the tokens to requests we send to the SP-API. We don't plan on using the generated *SDK classes.

I added a test which is somewhat limited, the change results in the header being lower cased in the "SignedHeaders" value but can't easily assert the signature used the lowercase header name due to the signature including a time component which in it's current state can't be easily mocked to return a static value. I avoided making additional changes past what was needed to resolve my issue to reduce the potential of the PR being rejected.

Please let me know if any changes are needed to get this merged. :)