### PR TITLE
Add ability to re-enable logging for APIs, operations, and headers

### DIFF
--- a/src/AmazonPHP/SellingPartner/Configuration.php
+++ b/src/AmazonPHP/SellingPartner/Configuration.php
@@ -181,14 +181,29 @@ final class Configuration
     {
         if ($operation !== null) {
             $this->loggerConfiguration->skipAPIOperation($api, $operation);
-        } else {
-            $this->loggerConfiguration->skipAPI($api);
+
+            return $this;
         }
+
+        $this->loggerConfiguration->skipAPI($api);
 
         return $this;
     }
 
-    public function loggingEnabled(string $api, string $operation) : bool
+    public function setEnableLogging(string $api, string $operation = null) : self
+    {
+        if ($operation !== null) {
+            $this->loggerConfiguration->enableAPIOperation($api, $operation);
+
+            return $this;
+        }
+
+        $this->loggerConfiguration->enableAPI($api);
+
+        return $this;
+    }
+
+    public function loggingEnabled(string $api, string $operation = null) : bool
     {
         return !$this->loggerConfiguration->isSkipped($api, $operation);
     }
@@ -196,6 +211,13 @@ final class Configuration
     public function loggingAddSkippedHeader(string $headerName) : self
     {
         $this->loggerConfiguration->addSkippedHeader($headerName);
+
+        return $this;
+    }
+
+    public function loggingRemoveSkippedHeader(string $headerName) : self
+    {
+        $this->loggerConfiguration->removeSkippedHeader($headerName);
 
         return $this;
     }

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/ConfigurationLoggingTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/ConfigurationLoggingTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Unit;
+
+use AmazonPHP\SellingPartner\Configuration;
+use AmazonPHP\SellingPartner\Configuration\LoggerConfiguration;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationLoggingTest extends TestCase
+{
+    private array $headers;
+
+    private array $apis;
+
+    private ?LoggerConfiguration $loggerConfiguration;
+
+    private ?Configuration $configuration;
+
+    protected function setUp() : void
+    {
+        $this->headers = [
+            'x-test-header-0',
+            'x-test-header-1',
+            'x-test-header-2',
+        ];
+
+        $this->apis = [
+            'TestApi0' => [
+                'TestApiOperation0',
+                'TestApiOperation1',
+                'TestApiOperation2',
+            ],
+            'TestApi1' => [
+                'TestApiOperation0',
+                'TestApiOperation1',
+                'TestApiOperation2',
+            ],
+            'TestApi2' => [
+                'TestApiOperation0',
+                'TestApiOperation1',
+                'TestApiOperation2',
+            ],
+        ];
+
+        $this->loggerConfiguration = new LoggerConfiguration();
+
+        $this->configuration = new Configuration(
+            'lwaClientID',
+            'lwaClientSecret',
+            'accessKey',
+            'secretKey',
+            null,
+            null,
+            $this->loggerConfiguration
+        );
+    }
+
+    protected function tearDown() : void
+    {
+        $this->headers = [];
+        $this->apis = [];
+        $this->configuration = null;
+        $this->loggerConfiguration = null;
+    }
+
+    public function test_can_set_skip_logging() : void
+    {
+        $this->addSkippedHeaders();
+
+        foreach ($this->headers as $header) {
+            $this->assertContains($header, $this->configuration->loggingSkipHeaders());
+        }
+
+        $this->assertNotContains('NotSkippedHeader', $this->configuration->loggingSkipHeaders());
+    }
+
+    public function test_can_remove_skipped_headers() : void
+    {
+        $this->addSkippedHeaders();
+
+        $this->configuration->loggingRemoveSkippedHeader($this->headers[0]);
+        $this->configuration->loggingRemoveSkippedHeader($this->headers[1]);
+
+        $this->assertNotContains($this->headers[0], $this->configuration->loggingSkipHeaders());
+        $this->assertNotContains($this->headers[1], $this->configuration->loggingSkipHeaders());
+
+        $this->assertContains($this->headers[2], $this->configuration->loggingSkipHeaders());
+    }
+
+    public function test_can_skip_api_logging() : void
+    {
+        $this->addSkippedApis();
+
+        foreach (array_keys($this->apis) as $api) {
+            $this->assertFalse($this->configuration->loggingEnabled($api));
+        }
+
+        $this->assertTrue($this->configuration->loggingEnabled('NotSkippedAPI'));
+    }
+
+    public function test_can_enable_api_logging() : void
+    {
+        $this->addSkippedApis();
+
+        $apis = array_keys($this->apis);
+
+        $this->configuration->setEnableLogging($apis[0]);
+
+        $this->assertTrue($this->configuration->loggingEnabled($apis[0]));
+        $this->assertFalse($this->configuration->loggingEnabled($apis[1]));
+        $this->assertFalse($this->configuration->loggingEnabled($apis[2]));
+    }
+
+    public function test_can_enable_api_logging_with_operations() : void
+    {
+        $this->addSkippedApiOperations();
+
+        $apiToEnable = array_keys($this->apis)[0];
+
+        $this->configuration->setEnableLogging($apiToEnable);
+
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                if ($api === $apiToEnable) {
+                    $this->assertTrue($this->configuration->loggingEnabled($api, $apiOperation));
+
+                    continue;
+                }
+
+                $this->assertFalse($this->configuration->loggingEnabled($api, $apiOperation));
+            }
+        }
+    }
+
+    public function test_can_skip_api_logging_operation() : void
+    {
+        $this->addSkippedApiOperations();
+
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                $this->assertFalse($this->configuration->loggingEnabled($api, $apiOperation));
+            }
+        }
+
+        foreach (\array_keys($this->apis) as $api) {
+            $this->assertTrue($this->configuration->loggingEnabled($api, 'NotSkippedOperation'));
+        }
+    }
+
+    public function test_can_enable_api_logging_operation() : void
+    {
+        $this->addSkippedApiOperations();
+
+        $apiToEnable = array_keys($this->apis)[0];
+        $apiOperationToEnable = $this->apis[$apiToEnable][1];
+
+        $this->configuration->setEnableLogging($apiToEnable, $apiOperationToEnable);
+
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                if ($api === $apiToEnable && $apiOperation === $apiOperationToEnable) {
+                    $this->asserttrue($this->configuration->loggingEnabled($api, $apiOperation));
+
+                    continue;
+                }
+
+                $this->assertFalse($this->configuration->loggingEnabled($api, $apiOperation));
+            }
+        }
+    }
+
+    private function addSkippedHeaders(): void
+    {
+        foreach ($this->headers as $header) {
+            $this->configuration->loggingAddSkippedHeader($header);
+        }
+    }
+
+    private function addSkippedApis(): void
+    {
+        foreach (array_keys($this->apis) as $api) {
+            $this->configuration->setSkipLogging($api);
+        }
+    }
+
+    private function addSkippedApiOperations(): void
+    {
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                $this->configuration->setSkipLogging($api, $apiOperation);
+            }
+        }
+    }
+}

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/LoggerConfigurationTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/LoggerConfigurationTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Unit;
+
+use AmazonPHP\SellingPartner\Configuration\LoggerConfiguration;
+use PHPUnit\Framework\TestCase;
+
+final class LoggerConfigurationTest extends TestCase
+{
+    private array $headers;
+
+    private array $apis;
+
+    private ?LoggerConfiguration $loggerConfiguration;
+
+    protected function setUp() : void
+    {
+        $this->headers = [
+            'x-test-header-0',
+            'x-test-header-1',
+            'x-test-header-2',
+        ];
+
+        $this->apis = [
+            'TestApi0' => [
+                'TestApiOperation0',
+                'TestApiOperation1',
+                'TestApiOperation2',
+            ],
+            'TestApi1' => [
+                'TestApiOperation0',
+                'TestApiOperation1',
+                'TestApiOperation2',
+            ],
+            'TestApi2' => [
+                'TestApiOperation0',
+                'TestApiOperation1',
+                'TestApiOperation2',
+            ],
+        ];
+
+        $this->loggerConfiguration = new LoggerConfiguration();
+    }
+
+    protected function tearDown() : void
+    {
+        $this->headers = [];
+        $this->apis = [];
+        $this->loggerConfiguration = null;
+    }
+
+    public function test_can_skip_headers() : void
+    {
+        $this->addSkippedHeaders();
+
+        foreach ($this->headers as $header) {
+            $this->assertContains($header, $this->loggerConfiguration->skipHeaders());
+        }
+
+        $this->assertNotContains('NotSkippedHeader', $this->loggerConfiguration->skipHeaders());
+    }
+
+    public function test_can_remove_skipped_headers() : void
+    {
+        $this->addSkippedHeaders();
+
+        $this->loggerConfiguration->removeSkippedHeader($this->headers[0]);
+        $this->loggerConfiguration->removeSkippedHeader($this->headers[1]);
+
+        $this->assertNotContains($this->headers[0], $this->loggerConfiguration->skipHeaders());
+        $this->assertNotContains($this->headers[1], $this->loggerConfiguration->skipHeaders());
+
+        $this->assertContains($this->headers[2], $this->loggerConfiguration->skipHeaders());
+    }
+
+    public function test_can_skip_api_logging() : void
+    {
+        $this->addSkippedApis();
+
+        foreach (array_keys($this->apis) as $api) {
+            $this->assertTrue($this->loggerConfiguration->isSkipped($api));
+        }
+
+        $this->assertFalse($this->loggerConfiguration->isSkipped('NotSkippedAPI'));
+    }
+
+    public function test_can_enable_api_logging() : void
+    {
+        $this->addSkippedApis();
+
+        $apis = array_keys($this->apis);
+
+        $this->loggerConfiguration->enableAPI($apis[0]);
+
+        $this->assertFalse($this->loggerConfiguration->isSkipped($apis[0]));
+        $this->assertTrue($this->loggerConfiguration->isSkipped($apis[1]));
+        $this->assertTrue($this->loggerConfiguration->isSkipped($apis[2]));
+    }
+
+    public function test_can_enable_api_logging_with_operations() : void
+    {
+        $this->addSkippedApiOperations();
+
+        $apiToEnable = array_keys($this->apis)[0];
+
+        $this->loggerConfiguration->enableAPI($apiToEnable);
+
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                if ($api === $apiToEnable) {
+                    $this->assertFalse($this->loggerConfiguration->isSkipped($api, $apiOperation));
+
+                    continue;
+                }
+
+                $this->assertTrue($this->loggerConfiguration->isSkipped($api, $apiOperation));
+            }
+        }
+    }
+
+    public function test_can_skip_api_logging_operation() : void
+    {
+        $this->addSkippedApiOperations();
+
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                $this->assertTrue($this->loggerConfiguration->isSkipped($api, $apiOperation));
+            }
+        }
+
+        foreach (\array_keys($this->apis) as $api) {
+            $this->assertFalse($this->loggerConfiguration->isSkipped($api, 'NotSkippedOperation'));
+        }
+    }
+
+    public function test_can_enable_api_logging_operation() : void
+    {
+        $this->addSkippedApiOperations();
+
+        $apiToEnable = array_keys($this->apis)[0];
+        $apiOperationToEnable = $this->apis[$apiToEnable][1];
+
+        $this->loggerConfiguration->enableAPIOperation($apiToEnable, $apiOperationToEnable);
+
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                if ($api === $apiToEnable && $apiOperation === $apiOperationToEnable) {
+                    $this->assertFalse($this->loggerConfiguration->isSkipped($api, $apiOperation));
+
+                    continue;
+                }
+
+                $this->assertTrue($this->loggerConfiguration->isSkipped($api, $apiOperation));
+            }
+        }
+    }
+
+    private function addSkippedHeaders(): void
+    {
+        foreach ($this->headers as $header) {
+            $this->loggerConfiguration->addSkippedHeader($header);
+        }
+    }
+
+    private function addSkippedApis(): void
+    {
+        foreach (array_keys($this->apis) as $api) {
+            $this->loggerConfiguration->skipAPI($api);
+        }
+    }
+
+    private function addSkippedApiOperations(): void
+    {
+        foreach ($this->apis as $api => $apiOperations) {
+            foreach ($apiOperations as $apiOperation) {
+                $this->loggerConfiguration->skipAPIOperation($api, $apiOperation);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix logic errors in existing LoggerConfiguration methods preventing proper handling of skip logging functionality.
Add new methods and operations to re-enable logging of API's and/or operations that were previously skipped.

<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add new methods and operations to the Configuration and LoggerConfiguration classes to re-enable logging of API's and/or operations that were previously skipped.</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fixed logic errors in existing LoggerConfiguration methods preventing proper handling of skip logging functionality.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<p>Corrected logic errors in LoggerConfiguration preventing proper handling of skip logging functionality and added new methods to re-enable logging of API's, operations, or headers that were previously skipped.</p>