### PR TITLE
support for when a type other than boolean is returned by the API, even though a boolean type is expected in the model.

### DIFF
--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -320,6 +320,18 @@ final class ObjectSerializer
 
         /** @psalm-suppress ParadoxicalCondition */
         if (\in_array($class, ['DateTime', 'DateTimeImmutable', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+            // If the model requires a Boolean type but the API returns a string.
+            if (($class === 'bool') || ($class === 'boolean')) {
+                $data = self::castToBoolean($data);
+            }
+
+            // If the model requires a string type but the API returns NULL.
+            if (($class === 'string')) {
+                if (null === $data) {
+                    $data = '';
+                }
+            }
+
             \settype($data, $class);
 
             return $data;
@@ -410,6 +422,25 @@ final class ObjectSerializer
             \ltrim(EventCode::class, '\\'),
             \ltrim(ItemImage::class, '\\'),
         ];
+    }
+
+    /**
+     * castToBoolean.
+     *
+     * Converts the given value to a boolean value
+     *
+     * @link https://www.php.net/manual/ja/function.boolval.php
+     *
+     * @param mixed $val Value to be converted
+     * @param bool $returnNull Default false, or false if null is not returned
+     *
+     * @return mixed boolean | NULL Value after conversion
+     */
+    private static function castToBoolean($val, $returnNull = false)
+    {
+        $boolval = (\is_string($val) ? \filter_var($val, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : (bool) $val);
+
+        return  $boolval===null && !$returnNull ? false : $boolval;
     }
 
     /**

--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -64,7 +64,13 @@ final class ObjectSerializer
                             /** array $callable */
                             $allowedEnumTypes = $callable();
 
-                            if (!\in_array($value->toString(), $allowedEnumTypes, true)) {
+                            $brokenModelDefinitions = [
+                                \ltrim(EventCode::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/191
+                                \ltrim(ItemImage::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/156
+                            ];
+
+                            if (!\in_array($value->toString(), $allowedEnumTypes, true) &&
+                                !\in_array(\ltrim($openAPIType, '\\'), $brokenModelDefinitions, true)) {
                                 $imploded = \implode("', '", $allowedEnumTypes);
 
                                 throw new \InvalidArgumentException("Invalid value for enum '{$openAPIType}', must be one of: '{$imploded}'");
@@ -345,12 +351,12 @@ final class ObjectSerializer
 
         if (\method_exists($class, 'getAllowableEnumValues')) {
             $brokenModelDefinitions = [
-                \ltrim(EventCode::class, '/'), // https://github.com/amazon-php/sp-api-sdk/issues/191
-                \ltrim(ItemImage::class, '/'), // https://github.com/amazon-php/sp-api-sdk/issues/156
+                \ltrim(EventCode::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/191
+                \ltrim(ItemImage::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/156
             ];
 
             // Do not validate if class is one of amazon broken model definitions.
-            if (\in_array(\ltrim($class, '/'), $brokenModelDefinitions, true)) {
+            if (\in_array(\ltrim($class, '\\'), $brokenModelDefinitions, true)) {
                 return new $class($data);
             }
 

--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -402,9 +402,9 @@ final class ObjectSerializer
      * https://github.com/amazon-php/sp-api-sdk/issues/191
      * https://github.com/amazon-php/sp-api-sdk/issues/156
      *
-     * @return array enum value class name
+     * @return array<class-string<ModelInterface>> enum value class name
      */
-    private function getBrokenModelDefinitions() : array
+    private static function getBrokenModelDefinitions() : array
     {
         return [
             \ltrim(EventCode::class, '\\'),

--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -64,13 +64,8 @@ final class ObjectSerializer
                             /** array $callable */
                             $allowedEnumTypes = $callable();
 
-                            $brokenModelDefinitions = [
-                                \ltrim(EventCode::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/191
-                                \ltrim(ItemImage::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/156
-                            ];
-
                             if (!\in_array($value->toString(), $allowedEnumTypes, true) &&
-                                !\in_array(\ltrim($openAPIType, '\\'), $brokenModelDefinitions, true)) {
+                                !\in_array(\ltrim($openAPIType, '\\'), self::getBrokenModelDefinitions(), true)) {
                                 $imploded = \implode("', '", $allowedEnumTypes);
 
                                 throw new \InvalidArgumentException("Invalid value for enum '{$openAPIType}', must be one of: '{$imploded}'");
@@ -350,13 +345,8 @@ final class ObjectSerializer
         }
 
         if (\method_exists($class, 'getAllowableEnumValues')) {
-            $brokenModelDefinitions = [
-                \ltrim(EventCode::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/191
-                \ltrim(ItemImage::class, '\\'), // https://github.com/amazon-php/sp-api-sdk/issues/156
-            ];
-
             // Do not validate if class is one of amazon broken model definitions.
-            if (\in_array(\ltrim($class, '\\'), $brokenModelDefinitions, true)) {
+            if (\in_array(\ltrim($class, '\\'), self::getBrokenModelDefinitions(), true)) {
                 return new $class($data);
             }
 
@@ -402,6 +392,24 @@ final class ObjectSerializer
         }
 
         return $instance;
+    }
+
+    /**
+     * Define a class name to disable enum value validation for incomplete model definitions.
+     *
+     * Due to an incomplete Amazon model definition, an unknown enum value in the API response would result in an exception and error during validation.
+     * This array defines in advance the class name of the enum value that will invalidate the validation, and returns it to the caller.
+     * https://github.com/amazon-php/sp-api-sdk/issues/191
+     * https://github.com/amazon-php/sp-api-sdk/issues/156
+     *
+     * @return array enum value class name
+     */
+    private function getBrokenModelDefinitions() : array
+    {
+        return [
+            \ltrim(EventCode::class, '\\'),
+            \ltrim(ItemImage::class, '\\'),
+        ];
     }
 
     /**


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add castToBoolean function</li>
  </ul> 
  <h4>Changed</h4>
  <ul id="changed">
    <li>Modification of the deserialize function</li>
  </ul>  
</div>
<hr/>

<h2>Description</h2>
<p>support for when a type other than boolean is returned by the API, even though a boolean type is expected in the model.</p>
<p>The `IsReplacementOrder` of <a href="https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference#order">Order</a>, returned by <a href="https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference#orderslist">OrdersList</a>, is `boolean` in the reference, but the actual values returned are the strings `"true"` and `"false"`.
This causes a malfunction in the <a href="https://github.com/amazon-php/sp-api-sdk/blob/4.x/src/AmazonPHP/SellingPartner/Model/Orders/Order.php#L1304">setIsReplacementOrder</a> function.</p>
<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->