### PR TITLE
Disabled validation for enums in fulfillment outbound api

### DIFF
--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -3,6 +3,8 @@
 namespace AmazonPHP\SellingPartner;
 
 use AmazonPHP\SellingPartner\Model\CatalogItem\ItemImage;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\AdditionalLocationInfo;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\CurrentStatus;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\EventCode;
 use AmazonPHP\SellingPartner\Model\MerchantFulfillment\LabelFormat;
 
@@ -399,8 +401,10 @@ final class ObjectSerializer
      *
      * Due to an incomplete Amazon model definition, an unknown enum value in the API response would result in an exception and error during validation.
      * This array defines in advance the class name of the enum value that will invalidate the validation, and returns it to the caller.
-     * https://github.com/amazon-php/sp-api-sdk/issues/191
-     * https://github.com/amazon-php/sp-api-sdk/issues/156
+     *
+     * EventCode - https://github.com/amazon-php/sp-api-sdk/issues/191
+     * ItemImage - https://github.com/amazon-php/sp-api-sdk/issues/156
+     * AdditionalLocationInfo & CurrentStatus - https://github.com/amzn/selling-partner-api-models/issues/257
      *
      * @return array<class-string<ModelInterface>> enum value class name
      */
@@ -409,6 +413,8 @@ final class ObjectSerializer
         return [
             \ltrim(EventCode::class, '\\'),
             \ltrim(ItemImage::class, '\\'),
+            \ltrim(AdditionalLocationInfo::class, '\\'),
+            \ltrim(CurrentStatus::class, '\\'),
         ];
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Disabled validation for enums in fulfillment outbound api</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Issue on Amazon's side - https://github.com/amzn/selling-partner-api-models/issues/257.