### PR TITLE
Disabled validation for FileType enum from Merchant Fulfillment API

### DIFF
--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -6,6 +6,7 @@ use AmazonPHP\SellingPartner\Model\CatalogItem\ItemImage;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\AdditionalLocationInfo;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\CurrentStatus;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\EventCode;
+use AmazonPHP\SellingPartner\Model\MerchantFulfillment\FileType;
 use AmazonPHP\SellingPartner\Model\MerchantFulfillment\LabelFormat;
 
 final class ObjectSerializer
@@ -415,6 +416,7 @@ final class ObjectSerializer
      * EventCode - https://github.com/amazon-php/sp-api-sdk/issues/191
      * ItemImage - https://github.com/amazon-php/sp-api-sdk/issues/156
      * AdditionalLocationInfo & CurrentStatus - https://github.com/amzn/selling-partner-api-models/issues/257
+     * FileType - https://github.com/amzn/selling-partner-api-models/issues/258
      *
      * @return array<class-string<ModelInterface>> enum value class name
      */
@@ -425,6 +427,7 @@ final class ObjectSerializer
             \ltrim(ItemImage::class, '\\'),
             \ltrim(AdditionalLocationInfo::class, '\\'),
             \ltrim(CurrentStatus::class, '\\'),
+            \ltrim(FileType::class, '\\'),
         ];
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Disabled validation for FileType enum from Merchant Fulfillment API</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
`cancelShipment` operation is returning empty string here.
Issue on Amazon's side - https://github.com/amzn/selling-partner-api-models/issues/258