### PR TITLE
Changed date time format during deserialization

### DIFF
--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -11,7 +11,7 @@ use AmazonPHP\SellingPartner\Model\MerchantFulfillment\LabelFormat;
 
 final class ObjectSerializer
 {
-    private static string $dateTimeFormat = \DateTimeInterface::ATOM;
+    private static string $dateTimeFormat = 'Y-m-d\TH:i:s.v\Z';
 
     /**
      * Change the date format.
@@ -39,7 +39,7 @@ final class ObjectSerializer
         }
 
         if ($data instanceof \DateTimeInterface) {
-            return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
+            return ($format === 'date') ? $data->format('Y-m-d') : $data->setTimezone(new \DateTimeZone('UTC'))->format(self::$dateTimeFormat);
         }
 
         if (\is_array($data)) {
@@ -193,8 +193,8 @@ final class ObjectSerializer
      */
     public static function toString($value) : string
     {
-        if ($value instanceof \DateTimeInterface) { // datetime in ISO8601 format
-            return $value->format(self::$dateTimeFormat);
+        if ($value instanceof \DateTimeInterface) { // datetime in ISO8601 zulu format
+            return $value->setTimezone(new \DateTimeZone('UTC'))->format(self::$dateTimeFormat);
         }
 
         if (\is_bool($value)) {

--- a/tests/AmazonPHP/SellingPartner/Tests/Functional/FulfillmentOutboundApiTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Functional/FulfillmentOutboundApiTest.php
@@ -6,10 +6,15 @@ namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Functional;
 
 use AmazonPHP\SellingPartner\Marketplace;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\Address;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\CODSettings;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\CreateFulfillmentOrderItem;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\CreateFulfillmentOrderRequest;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\FeatureSettings;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\FulfillmentAction;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\FulfillmentPreview;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\GetFulfillmentPreviewItem;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\GetFulfillmentPreviewRequest;
+use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\Money;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\ShippingSpeedCategory;
 
 final class FulfillmentOutboundApiTest extends SandboxTestCase
@@ -80,5 +85,56 @@ final class FulfillmentOutboundApiTest extends SandboxTestCase
 
         $this->assertCount(1, $response->getPayload()->getFulfillmentPreviews());
         $this->assertContainsOnlyInstancesOf(FulfillmentPreview::class, $response->getPayload()->getFulfillmentPreviews());
+    }
+
+    public function test_sandbox_create_fulfillment_order() : void
+    {
+        $marketplace = Marketplace::US();
+
+        $response = $this->sellingPartnerSDK->fulfillmentOutbound()->createFulfillmentOrder(
+            $this->sellingPartnerSDK->oAuth()->exchangeRefreshToken($this->sellerRefreshToken),
+            $marketplace->region(),
+            new CreateFulfillmentOrderRequest([
+                'marketplace_id' => 'ATVPDKIKX0DER',
+                'seller_fulfillment_order_id' => 'FBATestOrder-11',
+                'displayable_order_id' => 'TestOrder-FBAOutbound',
+                'displayable_order_date' => new \DateTime('2020-01-09T19:46:45.809Z'),
+                'displayable_order_comment' => 'TestOrder',
+                'shipping_speed_category' => new ShippingSpeedCategory(ShippingSpeedCategory::STANDARD),
+                'destination_address' => new Address([
+                    'name' => 'Amazon',
+                    'address_line1' => '1234 Amazon Way',
+                    'address_line2' => 'Suite 123',
+                    'address_line3' => 'Lane1',
+                    'city' => 'Troy',
+                    'state_or_region' => 'MI',
+                    'postal_code' => '48084',
+                    'country_code' => 'US',
+                ]),
+                'fulfillment_action' => new FulfillmentAction(FulfillmentAction::SHIP),
+                'cod_settings' => new CODSettings([
+                    'is_cod_required' => false,
+                    'cod_charge' => new Money(['value' => '10.00', 'currency_code' => 'USD']),
+                    'cod_charge_tax' => new Money(['value' => '2.00', 'currency_code' => 'USD']),
+                    'shipping_charge' => new Money(['value' => '5.00', 'currency_code' => 'USD']),
+                    'shipping_charge_tax' => new Money(['value' => '3.00', 'currency_code' => 'USD']),
+                ]),
+                'notification_emails' => ['test1%40amazon.com', 'test2%40amazon.com'],
+                'items' => [
+                    new CreateFulfillmentOrderItem([
+                        'seller_sku' => 'CR-47K6-H6QN',
+                        'seller_fulfillment_order_item_id' => 'OrderItemID1',
+                        'quantity' => 3,
+                    ]),
+                    new CreateFulfillmentOrderItem([
+                        'seller_sku' => 'PSMM-TEST-SKU-Jan-21_19_59_44-0738',
+                        'seller_fulfillment_order_item_id' => 'OrderItemID2',
+                        'quantity' => 1,
+                    ])
+                ],
+            ])
+        );
+
+        $this->assertNull($response->getErrors());
     }
 }

--- a/tests/AmazonPHP/SellingPartner/Tests/Functional/ReportsApiTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Functional/ReportsApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AmazonPHP\Test\AmazonPHP\SellingPartner\Tests\Functional;
 
 use AmazonPHP\SellingPartner\Marketplace;
+use AmazonPHP\SellingPartner\Model\Reports\CreateReportScheduleSpecification;
 use AmazonPHP\SellingPartner\Model\Reports\Report;
 
 final class ReportsApiTest extends SandboxTestCase
@@ -22,5 +23,23 @@ final class ReportsApiTest extends SandboxTestCase
 
         $this->assertCount(1, $response->getReports());
         $this->assertContainsOnlyInstancesOf(Report::class, $response->getReports());
+    }
+
+    public function test_sandbox_create_report_schedule() : void
+    {
+        $marketplace = Marketplace::US();
+
+        $response = $this->sellingPartnerSDK->reports()->createReportSchedule(
+            $this->sellingPartnerSDK->oAuth()->exchangeRefreshToken($this->sellerRefreshToken),
+            $marketplace->region(),
+            new CreateReportScheduleSpecification([
+                'report_type' => 'FEE_DISCOUNTS_REPORT',
+                'marketplace_ids' => ['A1PA6795UKMFR9', 'ATVPDKIKX0DER'],
+                'period' => 'PT5M',
+                'next_report_creation_time' => new \DateTime('2019-12-10T20:11:24.000Z'),
+            ])
+        );
+
+        $this->assertEquals("ID323", $response->getReportScheduleId());
     }
 }

--- a/tests/AmazonPHP/SellingPartner/Tests/Unit/ObjectSerializerTest.php
+++ b/tests/AmazonPHP/SellingPartner/Tests/Unit/ObjectSerializerTest.php
@@ -91,6 +91,34 @@ JSON
         );
     }
 
+    public function test_serialization_of_date_time_objects(): void
+    {
+        $this->assertEquals(
+            '2022-07-19',
+            ObjectSerializer::sanitizeForSerialization(new \DateTime('2022-07-19 10:15:35'), null, 'date')
+        );
+
+        $this->assertEquals(
+            '2022-07-19T10:15:35.000Z',
+            ObjectSerializer::sanitizeForSerialization(new \DateTime('2022-07-19 10:15:35'))
+        );
+
+        $this->assertEquals(
+            '2022-07-19T17:15:35.000Z',
+            ObjectSerializer::sanitizeForSerialization(new \DateTime('2022-07-19 10:15:35', new \DateTimeZone('America/Los_Angeles')))
+        );
+
+        $this->assertEquals(
+            '2022-07-19T17:15:35.000Z',
+            ObjectSerializer::toString(new \DateTime('2022-07-19 10:15:35', new \DateTimeZone('America/Los_Angeles')))
+        );
+
+        $this->assertEquals(
+            '2022-07-19T10:15:35.351Z',
+            ObjectSerializer::toString(new \DateTime('2022-07-19 10:15:35.351', new \DateTimeZone('UTC')))
+        );
+    }
+
     public function test_deserialize_label_format_enum_with_an_empty_string(): void
     {
         $response = <<<JSON


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Changed date time format during deserialization to zulu</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
Looks like amazon expects date time to be in ISO8601 in Zulu format, i.e. `2022-07-19T15:41:18.000Z`.
Passing format with offset like `2022-07-19T15:41:18+00:00` returns invalid input error.

For sure it works like that in orders(query params in `getOrder` endpoint) and outbound(`createFulfillmentOrder`) APIs. I've also checked expected sandbox requests and it's the same format there.