### PR TITLE
Add FulfillmentInbound `ShipmentStatus` to broken model definitions

### DIFF
--- a/src/AmazonPHP/SellingPartner/ObjectSerializer.php
+++ b/src/AmazonPHP/SellingPartner/ObjectSerializer.php
@@ -3,6 +3,7 @@
 namespace AmazonPHP\SellingPartner;
 
 use AmazonPHP\SellingPartner\Model\CatalogItem\ItemImage;
+use AmazonPHP\SellingPartner\Model\FulfillmentInbound\ShipmentStatus;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\AdditionalLocationInfo;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\CurrentStatus;
 use AmazonPHP\SellingPartner\Model\FulfillmentOutbound\EventCode;
@@ -417,6 +418,7 @@ final class ObjectSerializer
      * ItemImage - https://github.com/amazon-php/sp-api-sdk/issues/156
      * AdditionalLocationInfo & CurrentStatus - https://github.com/amzn/selling-partner-api-models/issues/257
      * FileType - https://github.com/amzn/selling-partner-api-models/issues/258
+     * ShipmentStatus - https://github.com/amzn/selling-partner-api-models/issues/270
      *
      * @return array<class-string<ModelInterface>> enum value class name
      */
@@ -428,6 +430,7 @@ final class ObjectSerializer
             \ltrim(AdditionalLocationInfo::class, '\\'),
             \ltrim(CurrentStatus::class, '\\'),
             \ltrim(FileType::class, '\\'),
+            \ltrim(ShipmentStatus::class, '\\'),
         ];
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add Fulfillment Inbound `ShipmentStatus` to broken model definitions.</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<p>The API returns an undocumented value of `READY_TO_SHIP` for the `ShipmentStatus` enum.</p>
<p>Ticket has been filed to have corrected at https://github.com/amzn/selling-partner-api-models/issues/270</p>