### PR TITLE
Force rector to always use in memory cache

### DIFF
--- a/rector-php.php
+++ b/rector-php.php
@@ -26,6 +26,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
+use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
@@ -47,6 +48,7 @@ return static function (RectorConfig $config): void {
         __DIR__ . '/src/AmazonPHP/SellingPartner/Marketplace.php',
         __DIR__ . '/src/AmazonPHP/SellingPartner/AccessToken.php',
     ]);
+    $config->cacheClass(MemoryCacheStorage::class);
 
     $config->rules([
         FixArgumentDefaultValuesNotMatchingTypeRector::class,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Forcing rector to always use in memory cache seems to resolve the issue where it starts adding redundant docblocks while regenerating models</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->