### PR TITLE
Fixed order model for non-existing orders

### DIFF
--- a/src/AmazonPHP/SellingPartner/Model/Orders/Order.php
+++ b/src/AmazonPHP/SellingPartner/Model/Orders/Order.php
@@ -682,7 +682,7 @@ class Order implements \ArrayAccess, \JsonSerializable, \Stringable, ModelInterf
     /**
      * Gets amazon_order_id.
      */
-    public function getAmazonOrderId() : string
+    public function getAmazonOrderId() : ?string
     {
         return $this->container['amazon_order_id'];
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
Apparently, calling AmazonPHP\SellingPartner\Api\OrdersV0Api\OrdersSDK::getOrder() using the non-existing order_id returns the empty AmazonPHP\SellingPartner\Model\Orders\Order model inside the wrapper object. We can do if ($order->getAmazonOrderId() === null) as the most logical check for non-existing order, but it fails since getAmazonOrderId is strictly type-checked as a string while it can possibly contain the null value.